### PR TITLE
feat: Add IPython magics to SDK

### DIFF
--- a/onepanel/couler/__init__.py
+++ b/onepanel/couler/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 
-__version__ = "1.0.0"
-
 from onepanel.couler.submitter import Submitter

--- a/onepanel/nbextensions/__init__.py
+++ b/onepanel/nbextensions/__init__.py
@@ -1,0 +1,4 @@
+from .magics import IPythonMagics
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(IPythonMagics)

--- a/onepanel/nbextensions/__init__.py
+++ b/onepanel/nbextensions/__init__.py
@@ -1,4 +1,6 @@
-from .magics import IPythonMagics
+from __future__ import absolute_import
+
+from onepanel.nbextensions.magics import IPythonMagics
 
 def load_ipython_extension(ipython):
     ipython.register_magics(IPythonMagics)

--- a/onepanel/nbextensions/magics.py
+++ b/onepanel/nbextensions/magics.py
@@ -1,0 +1,15 @@
+import os
+
+from IPython.core.magic import (Magics, magics_class, line_magic)
+from IPython.display import IFrame
+
+@magics_class
+class IPythonMagics(Magics):
+
+    @line_magic
+    def nni_ui(self, line):
+        src = '//{uid}--{namespace}.{domain}/nni'.format(
+            uid=os.getenv('ONEPANEL_RESOURCE_UID'),
+            namespace=os.getenv('ONEPANEL_RESOURCE_NAMESPACE'),
+            domain=os.getenv('ONEPANEL_DOMAIN'))
+        return IFrame(src=src, width='100%', height='500px')

--- a/onepanel/nbextensions/magics.py
+++ b/onepanel/nbextensions/magics.py
@@ -8,8 +8,13 @@ class IPythonMagics(Magics):
 
     @line_magic
     def nni_ui(self, line):
-        src = '//{uid}--{namespace}.{domain}/nni'.format(
-            uid=os.getenv('ONEPANEL_RESOURCE_UID'),
-            namespace=os.getenv('ONEPANEL_RESOURCE_NAMESPACE'),
-            domain=os.getenv('ONEPANEL_DOMAIN'))
+        domain = os.getenv('ONEPANEL_DOMAIN', 'localhost')
+
+        if domain == 'localhost':
+            src = '//{domain}:8080'.format(domain=domain, port=port)
+        else:
+            src = '//{uid}--{namespace}.{domain}/nni'.format(
+                uid=os.getenv('ONEPANEL_RESOURCE_UID'),
+                namespace=os.getenv('ONEPANEL_RESOURCE_NAMESPACE'),
+                domain=domain)
         return IFrame(src=src, width='100%', height='500px')

--- a/openapi/templates/setup.mustache
+++ b/openapi/templates/setup.mustache
@@ -31,7 +31,7 @@ class Install(InstallCommand):
     """ Customized setuptools install command which uses pip. """
 
     def run(self, *args, **kwargs):
-        subprocess.call([sys.executable, '-m', 'pip', 'install','git+https://github.com/couler-proj/couler'])
+        subprocess.call([sys.executable, '-m', 'pip', 'install','git+https://github.com/onepanelio/couler@dev'])
         InstallCommand.run(self, *args, **kwargs)
 
 setup(

--- a/openapi/templates/setup.mustache
+++ b/openapi/templates/setup.mustache
@@ -2,6 +2,7 @@
 
 {{>partial_header}}
 
+import sys
 import subprocess
 from setuptools import setup, find_packages  # noqa: H301
 from setuptools.command.install import install as InstallCommand
@@ -30,7 +31,7 @@ class Install(InstallCommand):
     """ Customized setuptools install command which uses pip. """
 
     def run(self, *args, **kwargs):
-        subprocess.call(['pip', 'install','git+https://github.com/couler-proj/couler'])
+        subprocess.call([sys.executable, '-m', 'pip', 'install','git+https://github.com/couler-proj/couler'])
         InstallCommand.run(self, *args, **kwargs)
 
 setup(


### PR DESCRIPTION
Currently NNI UI magic is supported, example in JupyterLab:

Load nbextensions
```
%load_ext onepanel.nbextensions
```
View NNI hyperparam tuning UI:
```
%nni_ui
```

Related: onepanelio/core#787

Note that the `%nni_ui` magic will not be functional until [this issue](https://github.com/microsoft/nni/issues/2771) is addressed